### PR TITLE
[ASSIST-555]: Add dark logo option to Brand Configuration

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -150,7 +150,6 @@ namespace App\Models{
  * @property string|null $locale
  * @property string|null $type
  * @property bool $is_external
- * @property string|null $team_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
@@ -181,7 +180,8 @@ namespace App\Models{
  * @property-read int|null $service_requests_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Notifications\Models\Subscription> $subscriptions
  * @property-read int|null $subscriptions_count
- * @property-read \Assist\Team\Models\Team|null $team
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Team\Models\Team> $teams
+ * @property-read int|null $teams_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Authorization\Models\RoleGroup> $traitRoleGroups
  * @property-read int|null $trait_role_groups_count
  * @method static \Illuminate\Database\Eloquent\Builder|User admins()
@@ -204,7 +204,6 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|User whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User wherePassword($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereRememberToken($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereTeamId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereType($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereUpdatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User withTrashed()
@@ -228,6 +227,7 @@ namespace Assist\Alert\Models{
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property \Assist\Alert\Enums\AlertStatus $status
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Audit\Models\Audit> $audits
  * @property-read int|null $audits_count
  * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $concern
@@ -236,6 +236,7 @@ namespace Assist\Alert\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|Alert newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Alert onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|Alert query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Alert status(\Assist\Alert\Enums\AlertStatus $status)
  * @method static \Illuminate\Database\Eloquent\Builder|Alert whereConcernId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Alert whereConcernType($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Alert whereCreatedAt($value)
@@ -598,15 +599,8 @@ namespace Assist\CaseloadManagement\Models{
 /**
  * Assist\CaseloadManagement\Models\Caseload
  *
- * @property string $id
- * @property string $name
- * @property array|null $filters
  * @property \Assist\CaseloadManagement\Enums\CaseloadModel $model
  * @property \Assist\CaseloadManagement\Enums\CaseloadType $type
- * @property string $user_id
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property string|null $deleted_at
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\CaseloadManagement\Models\CaseloadSubject> $subjects
  * @property-read int|null $subjects_count
  * @property-read \App\Models\User $user
@@ -614,15 +608,6 @@ namespace Assist\CaseloadManagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|Caseload newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Caseload newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Caseload query()
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereDeletedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereFilters($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereModel($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereName($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereType($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereUpdatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Caseload whereUserId($value)
  * @mixin \Eloquent
  */
 	#[\AllowDynamicProperties]
@@ -633,23 +618,11 @@ namespace Assist\CaseloadManagement\Models{
 /**
  * Assist\CaseloadManagement\Models\CaseloadSubject
  *
- * @property string $id
- * @property string $subject_id
- * @property string $subject_type
- * @property string $caseload_id
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Assist\CaseloadManagement\Models\Caseload $caseload
+ * @property-read \Assist\CaseloadManagement\Models\Caseload|null $caseload
  * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $subject
  * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject query()
- * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject whereCaseloadId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject whereSubjectId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject whereSubjectType($value)
- * @method static \Illuminate\Database\Eloquent\Builder|CaseloadSubject whereUpdatedAt($value)
  * @mixin \Eloquent
  */
 	#[\AllowDynamicProperties]
@@ -922,6 +895,54 @@ namespace Assist\Engagement\Models{
  */
 	#[\AllowDynamicProperties]
  class IdeHelperEngagementResponse {}
+}
+
+namespace Assist\Form\Models{
+/**
+ * Assist\Form\Models\Form
+ *
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Form\Models\FormField> $fields
+ * @property-read int|null $fields_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Form\Models\FormSubmission> $submissions
+ * @property-read int|null $submissions_count
+ * @method static \Assist\Form\Database\Factories\FormFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|Form newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Form newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Form query()
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperForm {}
+}
+
+namespace Assist\Form\Models{
+/**
+ * Assist\Form\Models\FormField
+ *
+ * @property-read \Assist\Form\Models\Form|null $form
+ * @method static \Assist\Form\Database\Factories\FormFieldFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|FormField newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|FormField newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|FormField query()
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperFormField {}
+}
+
+namespace Assist\Form\Models{
+/**
+ * Assist\Form\Models\FormSubmission
+ *
+ * @property-read \Assist\Form\Models\Form|null $form
+ * @method static \Assist\Form\Database\Factories\FormSubmissionFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|FormSubmission newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|FormSubmission newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|FormSubmission query()
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperFormSubmission {}
 }
 
 namespace Assist\Interaction\Models{
@@ -1724,7 +1745,6 @@ namespace Assist\Task\Models{
  *
  * @property-read Student|Prospect $concern
  * @property string $id
- * @property string $title
  * @property string $description
  * @property \Assist\Task\Enums\TaskStatus $status
  * @property \Illuminate\Support\Carbon|null $due
@@ -1755,7 +1775,6 @@ namespace Assist\Task\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|Task whereDue($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Task whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Task whereStatus($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Task whereTitle($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Task whereUpdatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Task withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|Task withoutTrashed()
@@ -1769,28 +1788,31 @@ namespace Assist\Team\Models{
 /**
  * Assist\Team\Models\Team
  *
- * @property string $id
- * @property string $name
- * @property string|null $description
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property string|null $deleted_at
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
  * @property-read int|null $users_count
  * @method static \Assist\Team\Database\Factories\TeamFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|Team newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Team newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Team query()
- * @method static \Illuminate\Database\Eloquent\Builder|Team whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Team whereDeletedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Team whereDescription($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Team whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Team whereName($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Team whereUpdatedAt($value)
  * @mixin \Eloquent
  */
 	#[\AllowDynamicProperties]
  class IdeHelperTeam {}
+}
+
+namespace Assist\Team\Models{
+/**
+ * Assist\Team\Models\TeamUser
+ *
+ * @property-read \Assist\Team\Models\Team|null $team
+ * @property-read \App\Models\User $user
+ * @method static \Illuminate\Database\Eloquent\Builder|TeamUser newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TeamUser newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TeamUser query()
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperTeamUser {}
 }
 
 namespace Assist\Webhook\Models{

--- a/app-modules/form/src/Models/Form.php
+++ b/app-modules/form/src/Models/Form.php
@@ -5,6 +5,9 @@ namespace Assist\Form\Models;
 use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @mixin IdeHelperForm
+ */
 class Form extends BaseModel
 {
     protected $fillable = [

--- a/app-modules/form/src/Models/FormField.php
+++ b/app-modules/form/src/Models/FormField.php
@@ -5,6 +5,9 @@ namespace Assist\Form\Models;
 use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @mixin IdeHelperFormField
+ */
 class FormField extends BaseModel
 {
     protected $fillable = [

--- a/app-modules/form/src/Models/FormSubmission.php
+++ b/app-modules/form/src/Models/FormSubmission.php
@@ -5,6 +5,9 @@ namespace Assist\Form\Models;
 use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @mixin IdeHelperFormSubmission
+ */
 class FormSubmission extends BaseModel
 {
     protected $fillable = [

--- a/app-modules/team/src/Models/TeamUser.php
+++ b/app-modules/team/src/Models/TeamUser.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @mixin IdeHelperTeamUser
+ */
 class TeamUser extends Pivot
 {
     use HasUuids;

--- a/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
@@ -45,7 +45,6 @@ class ManageBrandConfigurationSettings extends SettingsPage
                             ->deleteUploadedFileUsing(fn (Set $set) => $set('is_logo_active', false))
                             ->hiddenLabel(),
                         SpatieMediaLibraryFileUpload::make('dark_logo')
-                            ->label('Dark logo')
                             ->disk('s3')
                             ->collection('dark_logo')
                             ->visibility('private')

--- a/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
@@ -44,18 +44,19 @@ class ManageBrandConfigurationSettings extends SettingsPage
                             ->afterStateUpdated(fn (Set $set) => $set('is_logo_active', true))
                             ->deleteUploadedFileUsing(fn (Set $set) => $set('is_logo_active', false))
                             ->hiddenLabel(),
+                        SpatieMediaLibraryFileUpload::make('dark_logo')
+                            ->label('Dark logo')
+                            ->disk('s3')
+                            ->collection('dark_logo')
+                            ->visibility('private')
+                            ->image()
+                            ->model(
+                                SettingsProperty::getInstance('theme.is_logo_active'),
+                            )
+                            ->hidden(fn (Get $get): bool => blank($get('logo'))),
                         Toggle::make('is_logo_active')
                             ->label('Active')
-                            ->disabled(fn (Get $get): bool => blank($get('logo')))
-                            ->hint(fn (Get $get): ?string => blank($get('logo')) ? 'Please upload a logo to activate it.' : null)
-                            ->dehydrated()
-                            ->dehydrateStateUsing(function (Get $get, $state) {
-                                if (! filled($get('logo'))) {
-                                    return false;
-                                }
-
-                                return $state;
-                            }),
+                            ->hidden(fn (Get $get): bool => blank($get('logo'))),
                     ]),
             ]);
     }

--- a/app/Models/SettingsProperty.php
+++ b/app/Models/SettingsProperty.php
@@ -29,7 +29,7 @@ class SettingsProperty extends BaseSettingsProperty implements HasMedia
     public function registerMediaConversions(Media $media = null): void
     {
         $this->addMediaConversion('logo-height-250px')
-            ->performOnCollections('logo')
+            ->performOnCollections('logo', 'dark_logo')
             ->height(250);
     }
 }

--- a/resources/views/vendor/filament-panels/components/logo.blade.php
+++ b/resources/views/vendor/filament-panels/components/logo.blade.php
@@ -3,21 +3,35 @@
     use Assist\Theme\Settings\ThemeSettings;
 
     $themeSettings = app(ThemeSettings::class);
+
+    $settingsProperty = SettingsProperty::getInstance('theme.is_logo_active');
+    $logo = $settingsProperty->getFirstMedia('logo');
+    $darkLogo = $settingsProperty->getFirstMedia('dark_logo');
 @endphp
 
-@if ($themeSettings->is_logo_active)
+@if ($themeSettings->is_logo_active && $logo)
     <img
-        src="{{
-            SettingsProperty::getInstance('theme.is_logo_active')
-                ->getFirstMedia('logo')
-                ->getTemporaryUrl(
-                    expiration: now()->addMinutes(5),
-                    conversionName: 'logo-height-250px',
-                )
-        }}"
+        src="{{ $logo->getTemporaryUrl(
+            expiration: now()->addMinutes(5),
+            conversionName: 'logo-height-250px',
+        ) }}"
         alt="{{ config('app.name') }}"
-        class="h-9"
+        @class([
+            'h-9',
+            'dark:hidden' => $darkLogo,
+        ])
     />
+
+    @if ($darkLogo)
+        <img
+            src="{{ $darkLogo->getTemporaryUrl(
+                expiration: now()->addMinutes(5),
+                conversionName: 'logo-height-250px',
+            ) }}"
+            alt="{{ config('app.name') }}"
+            class="h-9 hidden dark:block"
+        />
+    @endif
 @else
     <div class="fi-logo text-xl font-bold leading-5 tracking-tight text-gray-950 dark:text-white">
         {{ config('app.name') }}


### PR DESCRIPTION
Also, both the `Active` and `Dark logo` fields have been hidden when the logo has not been uploaded yet, to clear things up visually.